### PR TITLE
Append terraform version to go-ztcentral user agents

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -14,7 +14,7 @@ builds:
   flags:
     - -trimpath
   ldflags:
-    - '-s -w -X main.version={{.Version}} -X main.commit={{.Commit}}'
+    - '-s -w -X pkg/zerotier.Version={{.Version}}'
   goos:
     - freebsd
     - windows

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ BINARY=terraform-provider-${NAME}
 VERSION=0.2.0
 OS_ARCH=$(shell go env GOOS)_$(shell go env GOARCH)
 GOLANGCI_LINT_VERSION=1.34.1
+BUILD=go build -ldflags "-X pkg/zerotier.Version=${VERSION}" -o
 
 ifeq ($(QUIET_TESTS),)
 TEST_VERBOSE = -v
@@ -31,21 +32,21 @@ mktfrc:
 	sh mktfrc.sh
 
 build:
-	go build -o ${BINARY}
+	${BUILD} ${BINARY}
 
 release:
-	GOOS=darwin GOARCH=amd64 go build -o ./bin/${BINARY}_${VERSION}_darwin_amd64
-	GOOS=freebsd GOARCH=386 go build -o ./bin/${BINARY}_${VERSION}_freebsd_386
-	GOOS=freebsd GOARCH=amd64 go build -o ./bin/${BINARY}_${VERSION}_freebsd_amd64
-	GOOS=freebsd GOARCH=arm go build -o ./bin/${BINARY}_${VERSION}_freebsd_arm
-	GOOS=linux GOARCH=386 go build -o ./bin/${BINARY}_${VERSION}_linux_386
-	GOOS=linux GOARCH=amd64 go build -o ./bin/${BINARY}_${VERSION}_linux_amd64
-	GOOS=linux GOARCH=arm go build -o ./bin/${BINARY}_${VERSION}_linux_arm
-	GOOS=openbsd GOARCH=386 go build -o ./bin/${BINARY}_${VERSION}_openbsd_386
-	GOOS=openbsd GOARCH=amd64 go build -o ./bin/${BINARY}_${VERSION}_openbsd_amd64
-	GOOS=solaris GOARCH=amd64 go build -o ./bin/${BINARY}_${VERSION}_solaris_amd64
-	GOOS=windows GOARCH=386 go build -o ./bin/${BINARY}_${VERSION}_windows_386
-	GOOS=windows GOARCH=amd64 go build -o ./bin/${BINARY}_${VERSION}_windows_amd64
+	GOOS=darwin GOARCH=amd64 ${BUILD} ./bin/${BINARY}_${VERSION}_darwin_amd64
+	GOOS=freebsd GOARCH=386 ${BUILD} ./bin/${BINARY}_${VERSION}_freebsd_386
+	GOOS=freebsd GOARCH=amd64 ${BUILD} ./bin/${BINARY}_${VERSION}_freebsd_amd64
+	GOOS=freebsd GOARCH=arm ${BUILD} ./bin/${BINARY}_${VERSION}_freebsd_arm
+	GOOS=linux GOARCH=386 ${BUILD} ./bin/${BINARY}_${VERSION}_linux_386
+	GOOS=linux GOARCH=amd64 ${BUILD} ./bin/${BINARY}_${VERSION}_linux_amd64
+	GOOS=linux GOARCH=arm ${BUILD} ./bin/${BINARY}_${VERSION}_linux_arm
+	GOOS=openbsd GOARCH=386 ${BUILD} ./bin/${BINARY}_${VERSION}_openbsd_386
+	GOOS=openbsd GOARCH=amd64 ${BUILD} ./bin/${BINARY}_${VERSION}_openbsd_amd64
+	GOOS=solaris GOARCH=amd64 ${BUILD} ./bin/${BINARY}_${VERSION}_solaris_amd64
+	GOOS=windows GOARCH=386 ${BUILD} ./bin/${BINARY}_${VERSION}_windows_386
+	GOOS=windows GOARCH=amd64 ${BUILD} ./bin/${BINARY}_${VERSION}_windows_amd64
 
 install: build
 	mkdir -p ~/.terraform.d/plugins/${HOSTNAME}/${NAMESPACE}/${NAME}/${VERSION}/${OS_ARCH}
@@ -56,7 +57,7 @@ fmt:
 	terraform fmt -recursive .
 
 test-build:
-	go build -o .tfdata/registry.terraform.io/hashicorp/zerotier/${VERSION}/${OS_ARCH}/${BINARY}
+	${BUILD} .tfdata/registry.terraform.io/hashicorp/zerotier/${VERSION}/${OS_ARCH}/${BINARY}
 
 test: test-image mktfrc test-build
 	go test ${TEST_VERBOSE} ./... ${TEST_COUNT} ${RUN_TEST} -p 1 # one test at at time

--- a/go.mod
+++ b/go.mod
@@ -36,7 +36,7 @@ require (
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.0.1 // indirect
 	github.com/sirupsen/logrus v1.7.0 // indirect
-	github.com/zerotier/go-ztcentral v0.2.1-0.20210213070016-be6aaad4acde
+	github.com/zerotier/go-ztcentral v0.2.1-0.20210219000718-2c130d86a959
 	github.com/zerotier/go-ztidentity v1.0.0
 	golang.org/x/net v0.0.0-20210119194325-5f4716e94777 // indirect
 	golang.org/x/text v0.3.5 // indirect

--- a/go.sum
+++ b/go.sum
@@ -373,6 +373,8 @@ github.com/zclconf/go-cty v1.7.1/go.mod h1:VDR4+I79ubFBGm1uJac1226K5yANQFHeauxPB
 github.com/zclconf/go-cty-debug v0.0.0-20191215020915-b22d67c1ba0b/go.mod h1:ZRKQfBXbGkpdV6QMzT3rU1kSTAnfu1dO8dPKjYprgj8=
 github.com/zerotier/go-ztcentral v0.2.1-0.20210213070016-be6aaad4acde h1:RlNjDsKOiZO25gT2zYaUoxagUPtb7Jx7VPF5fpzW4Es=
 github.com/zerotier/go-ztcentral v0.2.1-0.20210213070016-be6aaad4acde/go.mod h1:90weKZT7Rdq02tdJskc+XR8W93bMgL/9uMCq4Txz0Hk=
+github.com/zerotier/go-ztcentral v0.2.1-0.20210219000718-2c130d86a959 h1:9pVpqFdcxXn3iUDMZBAFzGn/wTw9GIIawk4Cm3jLSEc=
+github.com/zerotier/go-ztcentral v0.2.1-0.20210219000718-2c130d86a959/go.mod h1:90weKZT7Rdq02tdJskc+XR8W93bMgL/9uMCq4Txz0Hk=
 github.com/zerotier/go-ztidentity v1.0.0 h1:dgm1ChTxw1TXMrSJQ6VWK2RmHKVYqRd69h/Co/RG+xo=
 github.com/zerotier/go-ztidentity v1.0.0/go.mod h1:zcOy+qXl5A01QhR6dfqOTPiHFMBEjgPlPpDPAO+2jg4=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=

--- a/pkg/zerotier/provider.go
+++ b/pkg/zerotier/provider.go
@@ -2,6 +2,7 @@ package zerotier
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -46,6 +47,8 @@ func providerConfigure(ctx context.Context, d *schema.ResourceData) (interface{}
 		if ztControllerURL != "" {
 			c.BaseURL = ztControllerURL
 		}
+
+		c.SetUserAgent(fmt.Sprintf("terraform-provider-zerotier/%s", Version))
 
 		return c, nil
 	}

--- a/pkg/zerotier/version.go
+++ b/pkg/zerotier/version.go
@@ -1,0 +1,4 @@
+package zerotier
+
+// Version of product
+var Version = "<improperly built artifact>"


### PR DESCRIPTION
This adds versioning + user agent appending for the terraform plugin. It also upgrade go-ztcentral to the latest master.

Signed-off-by: Erik Hollensbe <github@hollensbe.org>
