### PR TITLE
Make `make install` easier to use by overwriting the release plugin in ~/.terraform.d

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
-HOSTNAME=zerotier.com
-NAMESPACE=dev
+HOSTNAME=registry.terraform.io
+NAMESPACE=zerotier
 NAME=zerotier
 BINARY=terraform-provider-${NAME}
 VERSION=0.2.0


### PR DESCRIPTION
Signed-off-by: Erik Hollensbe <linux@hollensbe.org>
