### PR TITLE
Fix version tagging

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -14,7 +14,7 @@ builds:
   flags:
     - -trimpath
   ldflags:
-    - '-s -w -X pkg/zerotier.Version={{.Version}}'
+    - '-s -w -X github.com/zerotier/terraform-provider-zerotier/pkg/zerotier.Version={{ .Version }}'
   goos:
     - freebsd
     - windows
@@ -36,7 +36,7 @@ builds:
     - goarm: mips64
       gomips: hardfloat
           
-  binary: '{{ .ProjectName }}_v{{ .Version }}'
+  binary: '{{ .ProjectName }}_{{ .Version }}'
 archives:
 - format: zip
   name_template: '{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}'

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ BINARY=terraform-provider-${NAME}
 VERSION=0.2.0
 OS_ARCH=$(shell go env GOOS)_$(shell go env GOARCH)
 GOLANGCI_LINT_VERSION=1.34.1
-BUILD=go build -ldflags "-X pkg/zerotier.Version=${VERSION}" -o
+BUILD=go build -ldflags "-X github.com/zerotier/terraform-provider-zerotier/pkg/zerotier.Version=${VERSION}" -o
 
 ifeq ($(QUIET_TESTS),)
 TEST_VERBOSE = -v

--- a/pkg/zerotier/provider.go
+++ b/pkg/zerotier/provider.go
@@ -11,7 +11,8 @@ import (
 	"github.com/zerotier/go-ztcentral"
 )
 
-func init() {
+// Provider -
+func Provider() *schema.Provider {
 	logrus.SetOutput(os.Stderr)
 	level, err := logrus.ParseLevel(os.Getenv("TF_LOG"))
 	if err != nil {
@@ -19,11 +20,7 @@ func init() {
 	}
 
 	logrus.SetLevel(level)
-}
-
-// Provider -
-func Provider() *schema.Provider {
-	logrus.Debug("ZeroTier provider initialized")
+	logrus.Infof("ZeroTier %s provider initialized", Version)
 
 	return &schema.Provider{
 		Schema: map[string]*schema.Schema{


### PR DESCRIPTION
Recent versions of golang seem to want to use the fully qualified
package path instead of allowing a relative one, which is what was used
before. Thanks to @glimberg for helping me diagnose this.

Signed-off-by: Erik Hollensbe <linux@hollensbe.org>

Since goreleaser is not tested as a part of our suite, this portion will need manual testing before release.