### PR TITLE
feat: support importing network resource

### DIFF
--- a/docs/resources/network.md
+++ b/docs/resources/network.md
@@ -80,4 +80,10 @@ Optional:
 
 - **via** (String) Gateway address
 
+## Import
 
+Networks can be imported using their ID, e.g.
+
+```
+$ terraform import zerotier_network.network 8056c2e21c1930be
+```

--- a/pkg/zerotier/resource_network.go
+++ b/pkg/zerotier/resource_network.go
@@ -17,6 +17,9 @@ func resourceNetwork() *schema.Resource {
 		UpdateContext: resourceNetworkUpdate,
 		DeleteContext: resourceNetworkDelete,
 		Schema:        NetworkSchema,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 	}
 }
 


### PR DESCRIPTION
This allows importing `zerotier_network` resources using their IDs. I've tested it locally and was able to successfully import my network :)