### PR TITLE
Remove prefixes from assignment pool examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ resource "zerotier_network" "occams_router" {
   name        = "occams_router"
   description = "The prefix with largest number of bits is usually correct"
   assignment_pool {
-    start = "10.1.0.1/24"
-    end   = "10.1.0.254/24"
+    start = "10.1.0.1"
+    end   = "10.1.0.254"
   }
   route {
     target = "10.1.0.0/24"
@@ -42,8 +42,8 @@ resource "zerotier_network" "schrödingers_nat" {
   name        = "schrödingers_nat"
   description = "A packet's destination is simultaneiously Alice and Bob until observed by a NAT table."
   assignment_pool {
-    start = "10.2.0.1/24"
-    end   = "10.2.0.254/24"
+    start = "10.2.0.1"
+    end   = "10.2.0.254"
   }
   route {
     target = "10.2.0.0/24"
@@ -67,8 +67,8 @@ resource "zerotier_network" "silence_of_the_lan" {
   name        = "silence_of_the_lan"
   description = "It puts the bits in the bucket. It does this whenever it is told."
   assignment_pool {
-    start = "10.3.0.1/24"
-    end   = "10.3.0.254/24"
+    start = "10.3.0.1"
+    end   = "10.3.0.254"
   }
   route {
     target = "10.3.0.0/24"


### PR DESCRIPTION
Hey, 
I was pasting in some examples. Some of the ipassignment_pool examples had /24 at the end. 
`terraform plan` would then have a diff every time:

```
resource "zerotier_network" "nightshade" {
        id               = "a0cbf4b62acee046"
        name             = "cattail"
        # (6 unchanged attributes hidden)



      + assignment_pool {
          + end   = "10.1.0.254"
          + start = "10.1.0.1"
        }
      - assignment_pool {
          - end   = "10.1.0.254/24" -> null
          - start = "10.1.0.1/24" -> null
        }

        # (3 unchanged blocks hidden)
    }
```

I edited this in github. Hope it looks right.