### PR TITLE
Fix typo in docs/example

### DIFF
--- a/docs/resources/network.md
+++ b/docs/resources/network.md
@@ -17,11 +17,11 @@ resource "zerotier_network" "my_network" {
   name        = "<required>"
   description = "Managed by Terraform"
 
-  assign_ipv4 = {
+  assign_ipv4 {
     zerotier = true
   }
 
-  assign_ipv6 = {
+  assign_ipv6 {
     zerotier = true
     sixplane = false
     rfc4193  = false

--- a/examples/resources/zerotier_network/resource.tf
+++ b/examples/resources/zerotier_network/resource.tf
@@ -2,11 +2,11 @@ resource "zerotier_network" "my_network" {
   name        = "<required>"
   description = "Managed by Terraform"
 
-  assign_ipv4 = {
+  assign_ipv4 {
     zerotier = true
   }
 
-  assign_ipv6 = {
+  assign_ipv6 {
     zerotier = true
     sixplane = false
     rfc4193  = false


### PR DESCRIPTION
Looks like the type for these properties changed in 1.0.0

With the "=" you get error:

```
 on main.tf line 16, in resource "zerotier_network" "cacti_net":
│   16:   assign_ipv6 = {
│
│ An argument named "assign_ipv6" is not expected here. Did you mean to define a block of type "assign_ipv6"?

```