### PR TITLE
Fix `zerotier_member` import usage example

### DIFF
--- a/docs/resources/member.md
+++ b/docs/resources/member.md
@@ -52,5 +52,5 @@ resource "zerotier_member" "alice" {
 Members can be imported using their Network ID and Node ID, for example:
 
 ```
-$ terraform import zerotier_network.network "8056c2e21c1930be-1122334455"
+$ terraform import zerotier_member.alice "8056c2e21c1930be-1122334455"
 ```


### PR DESCRIPTION
One-line fix to make usage example of importing `zerotier_member` close to the real life
NB `alice` here is because on the example above we define a such network member, so that should make the example more intuitive.