### PR TITLE
Return human-readable error on malformed member id

### DIFF
--- a/pkg/zerotier/member.go
+++ b/pkg/zerotier/member.go
@@ -158,19 +158,22 @@ func memberToTerraform(d *schema.ResourceData, m *spec.Member) diag.Diagnostics 
 	ipv4Assignments, ipv6Assignments := assignedIpsGrouping(*m.Config.IpAssignments)
 	d.Set("ipv4_assignments", ipv4Assignments)
 	d.Set("ipv6_assignments", ipv6Assignments)
-	d.Set("rfc4193", rfc4193Address(d))
-	d.Set("sixplane", sixPlaneAddress(d))
+
+	nwid, nodeID, err := resourceNetworkAndNodeIdentifiers(d)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	d.Set("rfc4193", rfc4193Address(nwid, nodeID))
+	d.Set("sixplane", sixPlaneAddress(nwid, nodeID))
 
 	return nil
 }
 
-func sixPlaneAddress(d *schema.ResourceData) string {
-	nwid, nodeID := resourceNetworkAndNodeIdentifiers(d)
+func sixPlaneAddress(nwid, nodeID string) string {
 	return buildIPV6("fd" + nwid + "9993" + nodeID)
 }
 
-func rfc4193Address(d *schema.ResourceData) string {
-	nwid, nodeID := resourceNetworkAndNodeIdentifiers(d)
+func rfc4193Address(nwid, nodeID string) string {
 	nwidInt, _ := strconv.ParseUint(nwid, 16, 64)
 	networkMask := uint32((nwidInt >> 32) ^ nwidInt)
 	networkPrefix := strconv.FormatUint(uint64(networkMask), 16)

--- a/pkg/zerotier/resource_member.go
+++ b/pkg/zerotier/resource_member.go
@@ -2,6 +2,8 @@ package zerotier
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -30,7 +32,10 @@ func resourceMember() *schema.Resource {
 func resourceMemberRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	c := m.(*ztcentral.Client)
 
-	nwid, nodeId := resourceNetworkAndNodeIdentifiers(d)
+	nwid, nodeId, err := resourceNetworkAndNodeIdentifiers(d)
+	if err != nil {
+		return diag.FromErr(err)
+	}
 
 	member, err := c.GetMember(ctx, nwid, nodeId)
 	if err != nil {
@@ -82,13 +87,29 @@ func resourceMemberDelete(ctx context.Context, d *schema.ResourceData, m interfa
 	return nil
 }
 
-func resourceNetworkAndNodeIdentifiers(d *schema.ResourceData) (string, string) {
+func resourceNetworkAndNodeIdentifiers(d *schema.ResourceData) (string, string, error) {
 	nwid := d.Get("network_id").(string)
 	nodeID := d.Get("member_id").(string)
 
 	if nwid == "" && nodeID == "" {
-		parts := strings.Split(d.Id(), "-")
-		nwid, nodeID = parts[0], parts[1]
+		var err error
+		nwid, nodeID, err = parseMemberId(d.Id())
+		if err != nil {
+			return "", "", err
+		}
 	}
-	return nwid, nodeID
+	return nwid, nodeID, nil
+}
+
+func parseMemberId(id string) (string, string, error) {
+	parts := strings.SplitN(id, "-", 2)
+
+	if len(parts) != 2 {
+		return "", "", errors.New(fmt.Sprintf("invalid format: '%s' (wrong syntax)", id))
+	}
+	if parts[0] == "" || parts[1] == "" {
+		return "", "", errors.New(fmt.Sprintf("invalid format: '%s' (all components are required)", id))
+	}
+
+	return parts[0], parts[1], nil
 }

--- a/pkg/zerotier/resource_member_test.go
+++ b/pkg/zerotier/resource_member_test.go
@@ -1,0 +1,95 @@
+package zerotier
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_ResourceNetworkAndNodeIdentifiers_PresetValues(t *testing.T) {
+	tests := []struct {
+		desc           string
+		inputNetworkID string
+		inputMemberID  string
+	}{
+		{
+			desc:           "Preset values",
+			inputNetworkID: "0xcafe", inputMemberID: "0xbaby",
+		},
+		{
+			desc:           "Missing network ID",
+			inputNetworkID: "", inputMemberID: "0xbaby",
+		},
+		{
+			desc:           "Missing member ID",
+			inputNetworkID: "0xcafe", inputMemberID: "",
+		},
+	}
+
+	res := schema.Resource{Schema: MemberSchema}
+	for _, test := range tests {
+		t.Run(test.desc, func(t *testing.T) {
+			d := res.TestResourceData()
+			d.Set("network_id", test.inputNetworkID)
+			d.Set("member_id", test.inputMemberID)
+
+			nwid, nodeID, err := resourceNetworkAndNodeIdentifiers(d)
+			assert.NoError(t, err)
+			assert.Equal(t, test.inputNetworkID, nwid)
+			assert.Equal(t, test.inputMemberID, nodeID)
+		})
+	}
+}
+
+func Test_ResourceNetworkAndNodeIdentifiers_ParsingMemberID(t *testing.T) {
+	tests := []struct {
+		desc    string
+		inputId string
+
+		expectedErrPattern string
+		expectedNetworkID  string
+		expectedNodeId     string
+	}{
+		{
+			desc:               "Wrong syntax",
+			inputId:            "0xcafe",
+			expectedErrPattern: "invalid format.*(wrong syntax)",
+		},
+		{
+			desc:               "Missing network id",
+			inputId:            "0xcafe-",
+			expectedErrPattern: "invalid format.*(all components are required)",
+		},
+		{
+			desc:               "Missing node id",
+			inputId:            "-0xbaby",
+			expectedErrPattern: "invalid format.*(all components are required)",
+		},
+		{
+			desc:              "Wellformed",
+			inputId:           "0xcafe-0xbaby",
+			expectedNetworkID: "0xcafe", expectedNodeId: "0xbaby",
+		},
+	}
+
+	res := schema.Resource{Schema: MemberSchema}
+	for _, test := range tests {
+		t.Run(test.desc, func(t *testing.T) {
+			d := res.TestResourceData()
+			d.SetId(test.inputId)
+
+			nwid, nodeID, err := resourceNetworkAndNodeIdentifiers(d)
+
+			if test.expectedErrPattern != "" {
+				assert.Error(t, err)
+				assert.Regexp(t, test.expectedErrPattern, err.Error())
+				return
+			}
+
+			assert.NoError(t, err)
+			assert.Equal(t, test.expectedNetworkID, nwid)
+			assert.Equal(t, test.expectedNodeId, nodeID)
+		})
+	}
+}


### PR DESCRIPTION
## Context

While importing a resource member with an invalid id (expected is `networkid-nodeid`), I got a panic with a stack trace while [accessing non-existing slice item](https://github.com/zerotier/terraform-provider-zerotier/blob/01c85089ceb741c50302a0e3de0908125c47501d/pkg/zerotier/resource_member.go#L91). This error is pretty confusing and non-intuitive.

## The Change

This PR adds a validation while parsing `member_id` from `ResourceData` for `network_id` & `node_id`; once the parsing is failed, a human-readable error is propagated.